### PR TITLE
update copyright dates of Steven Yi

### DIFF
--- a/blue-application/src/blue/application/BlueManualAction.java
+++ b/blue-application/src/blue/application/BlueManualAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-application/src/blue/application/CsoundManualAction.java
+++ b/blue-application/src/blue/application/CsoundManualAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-application/src/blue/application/CsoundManualFramesAction.java
+++ b/blue-application/src/blue/application/CsoundManualFramesAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/Arrangement.java
+++ b/blue-core/src/blue/Arrangement.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/ArrangementEvent.java
+++ b/blue-core/src/blue/ArrangementEvent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/ArrangementListener.java
+++ b/blue-core/src/blue/ArrangementListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/BlueDataFileManager.java
+++ b/blue-core/src/blue/BlueDataFileManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free

--- a/blue-core/src/blue/CopyBuffer.java
+++ b/blue-core/src/blue/CopyBuffer.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/InstrumentAssignment.java
+++ b/blue-core/src/blue/InstrumentAssignment.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/InstrumentLibrary.java
+++ b/blue-core/src/blue/InstrumentLibrary.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/LiveData.java
+++ b/blue-core/src/blue/LiveData.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/Marker.java
+++ b/blue-core/src/blue/Marker.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/MarkersList.java
+++ b/blue-core/src/blue/MarkersList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/SoundLayerException.java
+++ b/blue-core/src/blue/SoundLayerException.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/SoundLayerListener.java
+++ b/blue-core/src/blue/SoundLayerListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/TransferableInstrument.java
+++ b/blue-core/src/blue/TransferableInstrument.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/BlueAction.java
+++ b/blue-core/src/blue/actions/BlueAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/DialogFlipAction.java
+++ b/blue-core/src/blue/actions/DialogFlipAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/KeyStrokeAction.java
+++ b/blue-core/src/blue/actions/KeyStrokeAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/RedoAction.java
+++ b/blue-core/src/blue/actions/RedoAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/TabSelectionAction.java
+++ b/blue-core/src/blue/actions/TabSelectionAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/actions/UndoAction.java
+++ b/blue-core/src/blue/actions/UndoAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/Automatable.java
+++ b/blue-core/src/blue/automation/Automatable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/LineColors.java
+++ b/blue-core/src/blue/automation/LineColors.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/Parameter.java
+++ b/blue-core/src/blue/automation/Parameter.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterIdList.java
+++ b/blue-core/src/blue/automation/ParameterIdList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterList.java
+++ b/blue-core/src/blue/automation/ParameterList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterListListener.java
+++ b/blue-core/src/blue/automation/ParameterListListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterListener.java
+++ b/blue-core/src/blue/automation/ParameterListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterTimeManager.java
+++ b/blue-core/src/blue/automation/ParameterTimeManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/automation/ParameterTimeManagerFactory.java
+++ b/blue-core/src/blue/automation/ParameterTimeManagerFactory.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/blueLive/LiveObject.java
+++ b/blue-core/src/blue/blueLive/LiveObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/components/lines/Line.java
+++ b/blue-core/src/blue/components/lines/Line.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/components/lines/LineList.java
+++ b/blue-core/src/blue/components/lines/LineList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/components/lines/LinePoint.java
+++ b/blue-core/src/blue/components/lines/LinePoint.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/components/lines/LineUtils.java
+++ b/blue-core/src/blue/components/lines/LineUtils.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/csoundDownload/Download.java
+++ b/blue-core/src/blue/csoundDownload/Download.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/EditModeListener.java
+++ b/blue-core/src/blue/event/EditModeListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/GroupMovementListener.java
+++ b/blue-core/src/blue/event/GroupMovementListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/GroupMovementSelectionList.java
+++ b/blue-core/src/blue/event/GroupMovementSelectionList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/PlayModeListener.java
+++ b/blue-core/src/blue/event/PlayModeListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/SelectionEvent.java
+++ b/blue-core/src/blue/event/SelectionEvent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/SelectionList.java
+++ b/blue-core/src/blue/event/SelectionList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/event/SelectionListener.java
+++ b/blue-core/src/blue/event/SelectionListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/midi/MidiInputProcessor.java
+++ b/blue-core/src/blue/midi/MidiInputProcessor.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/midi/MidiKeyMapping.java
+++ b/blue-core/src/blue/midi/MidiKeyMapping.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/midi/MidiVelocityMapping.java
+++ b/blue-core/src/blue/midi/MidiVelocityMapping.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/mixer/Channel.java
+++ b/blue-core/src/blue/mixer/Channel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/ChannelList.java
+++ b/blue-core/src/blue/mixer/ChannelList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/ChannelListListener.java
+++ b/blue-core/src/blue/mixer/ChannelListListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/Effect.java
+++ b/blue-core/src/blue/mixer/Effect.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2005
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/mixer/EffectCategory.java
+++ b/blue-core/src/blue/mixer/EffectCategory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/mixer/EffectManager.java
+++ b/blue-core/src/blue/mixer/EffectManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/EffectsChain.java
+++ b/blue-core/src/blue/mixer/EffectsChain.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/EffectsLibrary.java
+++ b/blue-core/src/blue/mixer/EffectsLibrary.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/mixer/EffectsObjectRegistry.java
+++ b/blue-core/src/blue/mixer/EffectsObjectRegistry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/Mixer.java
+++ b/blue-core/src/blue/mixer/Mixer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/mixer/Send.java
+++ b/blue-core/src/blue/mixer/Send.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/Code.java
+++ b/blue-core/src/blue/noteProcessor/Code.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/LineAddProcessor.java
+++ b/blue-core/src/blue/noteProcessor/LineAddProcessor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/LineMultiplyProcessor.java
+++ b/blue-core/src/blue/noteProcessor/LineMultiplyProcessor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/NoteProcessorChainMap.java
+++ b/blue-core/src/blue/noteProcessor/NoteProcessorChainMap.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/PythonProcessor.java
+++ b/blue-core/src/blue/noteProcessor/PythonProcessor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/TempoMapper.java
+++ b/blue-core/src/blue/noteProcessor/TempoMapper.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/TuningProcessor.java
+++ b/blue-core/src/blue/noteProcessor/TuningProcessor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/noteProcessor/ValueTimeMapper.java
+++ b/blue-core/src/blue/noteProcessor/ValueTimeMapper.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/AbstractInstrument.java
+++ b/blue-core/src/blue/orchestra/AbstractInstrument.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/BlueSynthBuilder.java
+++ b/blue-core/src/blue/orchestra/BlueSynthBuilder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/FlowGraphInstrument.java
+++ b/blue-core/src/blue/orchestra/FlowGraphInstrument.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/InstrumentCategory.java
+++ b/blue-core/src/blue/orchestra/InstrumentCategory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/orchestra/InstrumentUtilities.java
+++ b/blue-core/src/blue/orchestra/InstrumentUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/AutomatableBSBObject.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/AutomatableBSBObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBCheckBox.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBCheckBox.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBCompilationUnit.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBCompilationUnit.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdown.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdown.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdownItem.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdownItem.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdownItemList.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBDropdownItemList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBEnvelopeGenerator.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBEnvelopeGenerator.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBFileSelector.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBFileSelector.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterface.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterface.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterfaceListener.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterfaceListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBHSlider.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBHSlider.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBHSliderBank.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBHSliderBank.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBKnob.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBKnob.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBLabel.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBLabel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBLineObject.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBLineObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObject.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObjectEntry.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObjectEntry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObjectRegistry.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBObjectRegistry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBParameterList.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBParameterList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBSubChannelDropdown.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBSubChannelDropdown.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBTabbedPane.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBTabbedPane.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBTextField.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBTextField.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBVSlider.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBVSlider.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBVSliderBank.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBVSliderBank.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/BSBXYController.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/BSBXYController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/Preset.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/Preset.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/PresetGroup.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/PresetGroup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/blueSynthBuilder/UniqueNameManager.java
+++ b/blue-core/src/blue/orchestra/blueSynthBuilder/UniqueNameManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/editor/FlowGraphEditor.java
+++ b/blue-core/src/blue/orchestra/editor/FlowGraphEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/Constant.java
+++ b/blue-core/src/blue/orchestra/flowGraph/Constant.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/GraphUnit.java
+++ b/blue-core/src/blue/orchestra/flowGraph/GraphUnit.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/Port.java
+++ b/blue-core/src/blue/orchestra/flowGraph/Port.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/PortList.java
+++ b/blue-core/src/blue/orchestra/flowGraph/PortList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/TestFlowGraph.java
+++ b/blue-core/src/blue/orchestra/flowGraph/TestFlowGraph.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/orchestra/flowGraph/Unit.java
+++ b/blue-core/src/blue/orchestra/flowGraph/Unit.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/score/tempo/Tempo.java
+++ b/blue-core/src/blue/score/tempo/Tempo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/scripting/Script.java
+++ b/blue-core/src/blue/scripting/Script.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/scripting/ScriptExtension.java
+++ b/blue-core/src/blue/scripting/ScriptExtension.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/scripting/ScriptLibrary.java
+++ b/blue-core/src/blue/scripting/ScriptLibrary.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/search/BlueSearchType.java
+++ b/blue-core/src/blue/search/BlueSearchType.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/search/UDOLibrarySearch.java
+++ b/blue-core/src/blue/search/UDOLibrarySearch.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/AudioFile.java
+++ b/blue-core/src/blue/soundObject/AudioFile.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/soundObject/FrozenSoundObject.java
+++ b/blue-core/src/blue/soundObject/FrozenSoundObject.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/soundObject/GenericViewable.java
+++ b/blue-core/src/blue/soundObject/GenericViewable.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/soundObject/JMask.java
+++ b/blue-core/src/blue/soundObject/JMask.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/LineObject.java
+++ b/blue-core/src/blue/soundObject/LineObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/NoteParseException.java
+++ b/blue-core/src/blue/soundObject/NoteParseException.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/ObjectBuilder.java
+++ b/blue-core/src/blue/soundObject/ObjectBuilder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/ObjectBuilderRegistry.java
+++ b/blue-core/src/blue/soundObject/ObjectBuilderRegistry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/OnLoadProcessable.java
+++ b/blue-core/src/blue/soundObject/OnLoadProcessable.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2008
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/soundObject/PatternObject.java
+++ b/blue-core/src/blue/soundObject/PatternObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/SoundObjectEvent.java
+++ b/blue-core/src/blue/soundObject/SoundObjectEvent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/SoundObjectException.java
+++ b/blue-core/src/blue/soundObject/SoundObjectException.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/SoundObjectListener.java
+++ b/blue-core/src/blue/soundObject/SoundObjectListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/SoundObjectUtilities.java
+++ b/blue-core/src/blue/soundObject/SoundObjectUtilities.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/soundObject/StreamBuffer.java
+++ b/blue-core/src/blue/soundObject/StreamBuffer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/StreamGobbler.java
+++ b/blue-core/src/blue/soundObject/StreamGobbler.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/TrackerObject.java
+++ b/blue-core/src/blue/soundObject/TrackerObject.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/Accumulatable.java
+++ b/blue-core/src/blue/soundObject/jmask/Accumulatable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/GeneratorRegistry.java
+++ b/blue-core/src/blue/soundObject/jmask/GeneratorRegistry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/Maskable.java
+++ b/blue-core/src/blue/soundObject/jmask/Maskable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/Quantizable.java
+++ b/blue-core/src/blue/soundObject/jmask/Quantizable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/Segment.java
+++ b/blue-core/src/blue/soundObject/jmask/Segment.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * Based on CMask by Andre Bartetzki
  *

--- a/blue-core/src/blue/soundObject/jmask/Table.java
+++ b/blue-core/src/blue/soundObject/jmask/Table.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * Based on CMask by Andre Bartetzki
  *

--- a/blue-core/src/blue/soundObject/jmask/TablePoint.java
+++ b/blue-core/src/blue/soundObject/jmask/TablePoint.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * Based on CMask by Andre Bartetzki
  *

--- a/blue-core/src/blue/soundObject/jmask/probability/Beta.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Beta.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Cauchy.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Cauchy.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/DoubleOrTable.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/DoubleOrTable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Exponential.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Exponential.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Gaussian.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Gaussian.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Linear.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Linear.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/ProbabilityGenerator.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/ProbabilityGenerator.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Triangle.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Triangle.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Uniform.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Uniform.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/jmask/probability/Weibull.java
+++ b/blue-core/src/blue/soundObject/jmask/probability/Weibull.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/pattern/Pattern.java
+++ b/blue-core/src/blue/soundObject/pattern/Pattern.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/pianoRoll/PianoNote.java
+++ b/blue-core/src/blue/soundObject/pianoRoll/PianoNote.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/pianoRoll/Scale.java
+++ b/blue-core/src/blue/soundObject/pianoRoll/Scale.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/tracker/Column.java
+++ b/blue-core/src/blue/soundObject/tracker/Column.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/tracker/Track.java
+++ b/blue-core/src/blue/soundObject/tracker/Track.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/tracker/TrackList.java
+++ b/blue-core/src/blue/soundObject/tracker/TrackList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/tracker/TrackListListener.java
+++ b/blue-core/src/blue/soundObject/tracker/TrackListListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/soundObject/tracker/TrackerNote.java
+++ b/blue-core/src/blue/soundObject/tracker/TrackerNote.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/udo/OpcodeList.java
+++ b/blue-core/src/blue/udo/OpcodeList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/udo/UDOCategory.java
+++ b/blue-core/src/blue/udo/UDOCategory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/udo/UDOLibrary.java
+++ b/blue-core/src/blue/udo/UDOLibrary.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/src/blue/udo/UserDefinedOpcode.java
+++ b/blue-core/src/blue/udo/UserDefinedOpcode.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/undo/BlueAbstractUndoableEdit.java
+++ b/blue-core/src/blue/undo/BlueAbstractUndoableEdit.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/undo/NoStyleChangeUndoManager.java
+++ b/blue-core/src/blue/undo/NoStyleChangeUndoManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/DX7Lister.java
+++ b/blue-core/src/blue/utility/DX7Lister.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/EnvironmentVars.java
+++ b/blue-core/src/blue/utility/EnvironmentVars.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/FileUtilities.java
+++ b/blue-core/src/blue/utility/FileUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/ListUtil.java
+++ b/blue-core/src/blue/utility/ListUtil.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/MathUtils.java
+++ b/blue-core/src/blue/utility/MathUtils.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/MusicFunctions.java
+++ b/blue-core/src/blue/utility/MusicFunctions.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/NumberUtilities.java
+++ b/blue-core/src/blue/utility/NumberUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/ObjectRandomizer.java
+++ b/blue-core/src/blue/utility/ObjectRandomizer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/ObjectUtilities.java
+++ b/blue-core/src/blue/utility/ObjectUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/ScoreExpressionParser.java
+++ b/blue-core/src/blue/utility/ScoreExpressionParser.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/SoundFileUtilities.java
+++ b/blue-core/src/blue/utility/SoundFileUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/UDOUtilities.java
+++ b/blue-core/src/blue/utility/UDOUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/ValuesUtility.java
+++ b/blue-core/src/blue/utility/ValuesUtility.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/src/blue/utility/XMLUtilities.java
+++ b/blue-core/src/blue/utility/XMLUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/components/lines/LineTest.java
+++ b/blue-core/test/unit/src/blue/components/lines/LineTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/components/lines/LineUtilsTest.java
+++ b/blue-core/test/unit/src/blue/components/lines/LineUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/mixer/AllMixerTests.java
+++ b/blue-core/test/unit/src/blue/mixer/AllMixerTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/mixer/EffectsChainTest.java
+++ b/blue-core/test/unit/src/blue/mixer/EffectsChainTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/mixer/MixerNodeTest.java
+++ b/blue-core/test/unit/src/blue/mixer/MixerNodeTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/mixer/MixerTest.java
+++ b/blue-core/test/unit/src/blue/mixer/MixerTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/noteProcessor/AddProcessorTest.java
+++ b/blue-core/test/unit/src/blue/noteProcessor/AddProcessorTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/noteProcessor/CloneTest.java
+++ b/blue-core/test/unit/src/blue/noteProcessor/CloneTest.java
@@ -1,6 +1,6 @@
 ///*
 // * blue - object composition environment for csound
-// * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+// * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
 // *
 // * This program is free software; you can redistribute it and/or modify
 // * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/noteProcessor/NoteProcessorTests.java
+++ b/blue-core/test/unit/src/blue/noteProcessor/NoteProcessorTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/orchestra/CloneTest.java
+++ b/blue-core/test/unit/src/blue/orchestra/CloneTest.java
@@ -1,6 +1,6 @@
 ///*
 // * blue - object composition environment for csound
-// * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+// * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
 // *
 // * This program is free software; you can redistribute it and/or modify
 // * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/orchestra/InstrumentTests.java
+++ b/blue-core/test/unit/src/blue/orchestra/InstrumentTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/BSBCloneTest.java
+++ b/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/BSBCloneTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterfaceTest.java
+++ b/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/BSBGraphicInterfaceTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/UniqueNameManagerTest.java
+++ b/blue-core/test/unit/src/blue/orchestra/blueSynthBuilder/UniqueNameManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/test/unit/src/blue/soundObject/AudioFileTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/AudioFileTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/CloneTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/CloneTest.java
@@ -1,6 +1,6 @@
 ///*
 // * blue - object composition environment for csound
-// * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+// * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
 // *
 // * This program is free software; you can redistribute it and/or modify
 // * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/GenericScoreTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/GenericScoreTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/InstanceTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/InstanceTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/NoteTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/NoteTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/PatternObjectTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/PatternObjectTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/PolyObjectTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/PolyObjectTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/SoundObjectTests.java
+++ b/blue-core/test/unit/src/blue/soundObject/SoundObjectTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/TrackerObjectTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/TrackerObjectTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/soundObject/tracker/TrackListTest.java
+++ b/blue-core/test/unit/src/blue/soundObject/tracker/TrackListTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/udo/AllUDOTests.java
+++ b/blue-core/test/unit/src/blue/udo/AllUDOTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/udo/OpcodeListTest.java
+++ b/blue-core/test/unit/src/blue/udo/OpcodeListTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/utility/AllUtilityTests.java
+++ b/blue-core/test/unit/src/blue/utility/AllUtilityTests.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/utility/CSDUtilityTest.java
+++ b/blue-core/test/unit/src/blue/utility/CSDUtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-core/test/unit/src/blue/utility/NumberUtilitiesTest.java
+++ b/blue-core/test/unit/src/blue/utility/NumberUtilitiesTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/utility/ScoreExpressionParserTest.java
+++ b/blue-core/test/unit/src/blue/utility/ScoreExpressionParserTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/utility/ScoreUtilitiesTest.java
+++ b/blue-core/test/unit/src/blue/utility/ScoreUtilitiesTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-core/test/unit/src/blue/utility/TextUtilitiesTest.java
+++ b/blue-core/test/unit/src/blue/utility/TextUtilitiesTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-midi/src/blue/midi/BlueMidiDevice.java
+++ b/blue-midi/src/blue/midi/BlueMidiDevice.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2010 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-midi/src/blue/midi/MidiInputManager.java
+++ b/blue-midi/src/blue/midi/MidiInputManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-midi/src/blue/midi/MidiInputTableModel.java
+++ b/blue-midi/src/blue/midi/MidiInputTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2010 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-midi/src/blue/midi/MidiOptionsPanelController.java
+++ b/blue-midi/src/blue/midi/MidiOptionsPanelController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2010 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-midi/src/blue/midi/MidiPanel.java
+++ b/blue-midi/src/blue/midi/MidiPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2010 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-osc/src/blue/osc/OSCAction.java
+++ b/blue-osc/src/blue/osc/OSCAction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-osc/src/blue/osc/OSCManager.java
+++ b/blue-osc/src/blue/osc/OSCManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-osc/src/blue/osc/OSCOptionsPanelController.java
+++ b/blue-osc/src/blue/osc/OSCOptionsPanelController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueBorderUtilities.java
+++ b/blue-plaf/src/blue/plaf/BlueBorderUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueButtonBorder.java
+++ b/blue-plaf/src/blue/plaf/BlueButtonBorder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueEditorTabCellRenderer.java
+++ b/blue-plaf/src/blue/plaf/BlueEditorTabCellRenderer.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plaf/src/blue/plaf/BlueEditorTabDisplayerUI.java
+++ b/blue-plaf/src/blue/plaf/BlueEditorTabDisplayerUI.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plaf/src/blue/plaf/BlueGradients.java
+++ b/blue-plaf/src/blue/plaf/BlueGradients.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueMenuBarUI.java
+++ b/blue-plaf/src/blue/plaf/BlueMenuBarUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueMenuUI.java
+++ b/blue-plaf/src/blue/plaf/BlueMenuUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueScrollButton.java
+++ b/blue-plaf/src/blue/plaf/BlueScrollButton.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueTabControlButtonFactory.java
+++ b/blue-plaf/src/blue/plaf/BlueTabControlButtonFactory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plaf/src/blue/plaf/BlueTabbedPaneUI.java
+++ b/blue-plaf/src/blue/plaf/BlueTabbedPaneUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueTableHeaderBorder.java
+++ b/blue-plaf/src/blue/plaf/BlueTableHeaderBorder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueTableUI.java
+++ b/blue-plaf/src/blue/plaf/BlueTableUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueTextFieldBorder.java
+++ b/blue-plaf/src/blue/plaf/BlueTextFieldBorder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueToggleButtonBorder.java
+++ b/blue-plaf/src/blue/plaf/BlueToggleButtonBorder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueToolBarUI.java
+++ b/blue-plaf/src/blue/plaf/BlueToolBarUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueToolTipUI.java
+++ b/blue-plaf/src/blue/plaf/BlueToolTipUI.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/BlueViewBorder.java
+++ b/blue-plaf/src/blue/plaf/BlueViewBorder.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plaf/src/blue/plaf/BlueViewTabDisplayerUI.java
+++ b/blue-plaf/src/blue/plaf/BlueViewTabDisplayerUI.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plaf/src/blue/plaf/FastGradientPaintContext.java
+++ b/blue-plaf/src/blue/plaf/FastGradientPaintContext.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-plaf/src/blue/plaf/Installer.java
+++ b/blue-plaf/src/blue/plaf/Installer.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plugin/src/blue/plugin/BluePlugin.java
+++ b/blue-plugin/src/blue/plugin/BluePlugin.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-plugin/src/blue/plugin/DefaultBluePluginProvider.java
+++ b/blue-plugin/src/blue/plugin/DefaultBluePluginProvider.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/AudioFileDependencyDialog.java
+++ b/blue-projects/src/blue/projects/AudioFileDependencyDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-projects/src/blue/projects/BlueProjectManager.java
+++ b/blue-projects/src/blue/projects/BlueProjectManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free

--- a/blue-projects/src/blue/projects/actions/ImportCsdAction.java
+++ b/blue-projects/src/blue/projects/actions/ImportCsdAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/actions/ImportMidiAction.java
+++ b/blue-projects/src/blue/projects/actions/ImportMidiAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/actions/ImportOrcScoAction.java
+++ b/blue-projects/src/blue/projects/actions/ImportOrcScoAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/actions/RevertAction.java
+++ b/blue-projects/src/blue/projects/actions/RevertAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/actions/SaveAsProjectAction.java
+++ b/blue-projects/src/blue/projects/actions/SaveAsProjectAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/projects/actions/SaveProjectAction.java
+++ b/blue-projects/src/blue/projects/actions/SaveProjectAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-projects/src/blue/utility/midi/MidiImportSettings.java
+++ b/blue-projects/src/blue/utility/midi/MidiImportSettings.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-projects/src/blue/utility/midi/MidiImportUtilities.java
+++ b/blue-projects/src/blue/utility/midi/MidiImportUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-projects/src/blue/utility/midi/TrackImportSettings.java
+++ b/blue-projects/src/blue/utility/midi/TrackImportSettings.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/ColorSelectionPanel.java
+++ b/blue-settings/src/blue/settings/ColorSelectionPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/DiskRenderSettings.java
+++ b/blue-settings/src/blue/settings/DiskRenderSettings.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/DiskRenderSettingsOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/DiskRenderSettingsOptionsPanelController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/DiskRenderSettingsPanel.java
+++ b/blue-settings/src/blue/settings/DiskRenderSettingsPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/GeneralOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/GeneralOptionsPanelController.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/GeneralPanel.java
+++ b/blue-settings/src/blue/settings/GeneralPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/GeneralSettings.java
+++ b/blue-settings/src/blue/settings/GeneralSettings.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/PlaybackOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/PlaybackOptionsPanelController.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/PlaybackPanel.java
+++ b/blue-settings/src/blue/settings/PlaybackPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/PlaybackSettings.java
+++ b/blue-settings/src/blue/settings/PlaybackSettings.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/ProjectDefaultsOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/ProjectDefaultsOptionsPanelController.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/ProjectDefaultsPanel.java
+++ b/blue-settings/src/blue/settings/ProjectDefaultsPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/ProjectDefaultsSettings.java
+++ b/blue-settings/src/blue/settings/ProjectDefaultsSettings.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/ProjectPropertiesUtil.java
+++ b/blue-settings/src/blue/settings/ProjectPropertiesUtil.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/RealtimeRenderSettings.java
+++ b/blue-settings/src/blue/settings/RealtimeRenderSettings.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-settings/src/blue/settings/RealtimeRenderSettingsOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/RealtimeRenderSettingsOptionsPanelController.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/RealtimeRenderSettingsPanel.java
+++ b/blue-settings/src/blue/settings/RealtimeRenderSettingsPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/SettingsFileChooser.java
+++ b/blue-settings/src/blue/settings/SettingsFileChooser.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/UtilityOptionsPanelController.java
+++ b/blue-settings/src/blue/settings/UtilityOptionsPanelController.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/UtilityPanel.java
+++ b/blue-settings/src/blue/settings/UtilityPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-settings/src/blue/settings/UtilitySettings.java
+++ b/blue-settings/src/blue/settings/UtilitySettings.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-components/src/blue/ui/components/IconFactory.java
+++ b/blue-ui-components/src/blue/ui/components/IconFactory.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/MainToolBar.java
+++ b/blue-ui-core/src/blue/MainToolBar.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/WindowSettingManager.java
+++ b/blue-ui-core/src/blue/WindowSettingManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/WindowSettingsSavable.java
+++ b/blue-ui-core/src/blue/WindowSettingsSavable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/automation/AutomationManager.java
+++ b/blue-ui-core/src/blue/automation/AutomationManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/automation/ParameterLinePanel.java
+++ b/blue-ui-core/src/blue/automation/ParameterLinePanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/automation/ParameterTimeManagerImpl.java
+++ b/blue-ui-core/src/blue/automation/ParameterTimeManagerImpl.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/AlphaMarquee.java
+++ b/blue-ui-core/src/blue/components/AlphaMarquee.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/ColorCellEditor.java
+++ b/blue-ui-core/src/blue/components/ColorCellEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/ColorSelectionPanel.java
+++ b/blue-ui-core/src/blue/components/ColorSelectionPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/DockingSplitPane.java
+++ b/blue-ui-core/src/blue/components/DockingSplitPane.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/EditEnabledCheckBox.java
+++ b/blue-ui-core/src/blue/components/EditEnabledCheckBox.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/EditLabel.java
+++ b/blue-ui-core/src/blue/components/EditLabel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/Editable.java
+++ b/blue-ui-core/src/blue/components/Editable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/FileSelectionPanel.java
+++ b/blue-ui-core/src/blue/components/FileSelectionPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/FindReplaceDialog.java
+++ b/blue-ui-core/src/blue/components/FindReplaceDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/HandGrabberMouseListener.java
+++ b/blue-ui-core/src/blue/components/HandGrabberMouseListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/LabelledPanel.java
+++ b/blue-ui-core/src/blue/components/LabelledPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/components/LineCanvas.java
+++ b/blue-ui-core/src/blue/components/LineCanvas.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/PaletteWindow.java
+++ b/blue-ui-core/src/blue/components/PaletteWindow.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/TableHilightDropListener.java
+++ b/blue-ui-core/src/blue/components/TableHilightDropListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/TreeHilightDropListener.java
+++ b/blue-ui-core/src/blue/components/TreeHilightDropListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/ValueSlider.java
+++ b/blue-ui-core/src/blue/components/ValueSlider.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/lines/LineBoundaryDialog.java
+++ b/blue-ui-core/src/blue/components/lines/LineBoundaryDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/lines/LineColors.java
+++ b/blue-ui-core/src/blue/components/lines/LineColors.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/lines/LineEditorDialog.java
+++ b/blue-ui-core/src/blue/components/lines/LineEditorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/lines/LineListTable.java
+++ b/blue-ui-core/src/blue/components/lines/LineListTable.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/components/lines/LineUtils.java
+++ b/blue-ui-core/src/blue/components/lines/LineUtils.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/DialogUtil.java
+++ b/blue-ui-core/src/blue/gui/DialogUtil.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/DragManager.java
+++ b/blue-ui-core/src/blue/gui/DragManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/ExceptionDialog.java
+++ b/blue-ui-core/src/blue/gui/ExceptionDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/FileTree.java
+++ b/blue-ui-core/src/blue/gui/FileTree.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/blue-ui-core/src/blue/gui/FileTreeListener.java
+++ b/blue-ui-core/src/blue/gui/FileTreeListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/TabbedPaneSwitchDropTarget.java
+++ b/blue-ui-core/src/blue/gui/TabbedPaneSwitchDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/gui/TimedKeyListener.java
+++ b/blue-ui-core/src/blue/gui/TimedKeyListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/AlignmentPanel.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/AlignmentPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/AutomatableBSBObjectView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/AutomatableBSBObjectView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBCheckBoxView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBCheckBoxView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBCodeEditor.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBCodeEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBDropdownView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBDropdownView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBDropdownViewBeanInfo.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBDropdownViewBeanInfo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanel.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanelNonEditPopup.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanelNonEditPopup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanelPopup.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEditPanelPopup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEnvelopeGeneratorView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBEnvelopeGeneratorView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBFileSelectorPopup.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBFileSelectorPopup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBFileSelectorView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBFileSelectorView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBHSliderBankView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBHSliderBankView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBHSliderView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBHSliderView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBInterfaceEditor.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBInterfaceEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBKnobView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBKnobView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLabelView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLabelView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLineObjectView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLineObjectView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLineObjectViewBeanInfo.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBLineObjectViewBeanInfo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectEditPopup.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectEditPopup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectEditorFactory.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectEditorFactory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectPropertySheet.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectPropertySheet.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectViewHolder.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBObjectViewHolder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBSubChannelDropdownView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBSubChannelDropdownView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBTabbedPaneView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBTabbedPaneView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBTextFieldView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBTextFieldView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBVSliderBankView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBVSliderBankView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBVSliderView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBVSliderView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBXYControllerView.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/BSBXYControllerView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/DropdownItemEditorDialog.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/DropdownItemEditorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/DropdownItemsPropertyEditor.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/DropdownItemsPropertyEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/LineListEditorDialog.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/LineListEditorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/LineListPropertyEditor.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/LineListPropertyEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetListener.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsBuffer.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsBuffer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsManagerDialog.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsManagerDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsPanel.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeDragSource.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeDropTarget.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeModel.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsTreeModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsUtilities.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/PresetsUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/SeparatorTypePropertyEditor.java
+++ b/blue-ui-core/src/blue/orchestra/editor/blueSynthBuilder/SeparatorTypePropertyEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/AudioFileEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/AudioFileEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/FrozenSoundObjectEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/FrozenSoundObjectEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/JMaskEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/JMaskEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/LineEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/LineEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/ObjectBuilderEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/ObjectBuilderEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/PatternEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/PatternEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/PythonEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/PythonEditor.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2008
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/soundObject/editor/TrackerEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/TrackerEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/AccumulatorEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/AccumulatorEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/ConstantEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/ConstantEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/EditorListPanel.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/EditorListPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/GeneratorEditorFactory.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/GeneratorEditorFactory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/ItemListEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/ItemListEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/MaskEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/MaskEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/OscillatorEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/OscillatorEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/ParameterEditListener.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/ParameterEditListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/QuantizerEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/QuantizerEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/RandomEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/RandomEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/TableCanvas.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/TableCanvas.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2008 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/TableEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/TableEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2008 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * Based on CMask by Andre Bartetzki
  *

--- a/blue-ui-core/src/blue/soundObject/editor/jmask/probability/ProbabilityEditorFactory.java
+++ b/blue-ui-core/src/blue/soundObject/editor/jmask/probability/ProbabilityEditorFactory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/soundObject/editor/objectBuilder/ObjectBuilderCodeEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/objectBuilder/ObjectBuilderCodeEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pattern/PatternCanvas.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pattern/PatternCanvas.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pattern/PatternObjectPropertiesPanel.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pattern/PatternObjectPropertiesPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pattern/PatternScoreEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pattern/PatternScoreEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pattern/PatternTimeBar.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pattern/PatternTimeBar.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NoteBuffer.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NoteBuffer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NoteCanvasMouseListener.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NoteCanvasMouseListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NotePropertiesEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/NotePropertiesEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoNoteView.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoNoteView.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollCanvas.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollCanvas.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollCanvasHeader.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollCanvasHeader.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollPropertiesEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/PianoRollPropertiesEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/ScaleSelectionPanel.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/ScaleSelectionPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/SelectedNoteHighlighter.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/SelectedNoteHighlighter.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/TimeBar.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/TimeBar.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/pianoRoll/TimelinePropertiesPanel.java
+++ b/blue-ui-core/src/blue/soundObject/editor/pianoRoll/TimelinePropertiesPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/soundObject/editor/tracker/TracksEditor.java
+++ b/blue-ui-core/src/blue/soundObject/editor/tracker/TracksEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/soundObject/editor/tracker/TracksHeader.java
+++ b/blue-ui-core/src/blue/soundObject/editor/tracker/TracksHeader.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/LoginPage.java
+++ b/blue-ui-core/src/blue/tools/blueShare/LoginPage.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/NamePasswordPanel.java
+++ b/blue-ui-core/src/blue/tools/blueShare/NamePasswordPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/effects/EffectManagementTableModel.java
+++ b/blue-ui-core/src/blue/tools/blueShare/effects/EffectManagementTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/effects/EffectOptionTableModel.java
+++ b/blue-ui-core/src/blue/tools/blueShare/effects/EffectOptionTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/instruments/InstrumentManagementTableModel.java
+++ b/blue-ui-core/src/blue/tools/blueShare/instruments/InstrumentManagementTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/blueShare/instruments/InstrumentOptionTableModel.java
+++ b/blue-ui-core/src/blue/tools/blueShare/instruments/InstrumentOptionTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/AddToCodeRepositoryDialog.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/AddToCodeRepositoryDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryDragSource.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryDropTarget.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryDropTarget.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryManager.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryPopup.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryPopup.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryTreeNode.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/CodeRepositoryTreeNode.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/ElementHolder.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/ElementHolder.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/codeRepository/TransferableTreeNode.java
+++ b/blue-ui-core/src/blue/tools/codeRepository/TransferableTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/tools/soundFont/InstrumentInfo.java
+++ b/blue-ui-core/src/blue/tools/soundFont/InstrumentInfo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/soundFont/InstrumentInfoTableModel.java
+++ b/blue-ui-core/src/blue/tools/soundFont/InstrumentInfoTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/soundFont/PresetInfo.java
+++ b/blue-ui-core/src/blue/tools/soundFont/PresetInfo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/soundFont/PresetInfoTableModel.java
+++ b/blue-ui-core/src/blue/tools/soundFont/PresetInfoTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/soundFont/SoundFontInfo.java
+++ b/blue-ui-core/src/blue/tools/soundFont/SoundFontInfo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/tools/soundFont/SoundFontUtility.java
+++ b/blue-ui-core/src/blue/tools/soundFont/SoundFontUtility.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as

--- a/blue-ui-core/src/blue/tools/soundFont/SoundFontViewer.java
+++ b/blue-ui-core/src/blue/tools/soundFont/SoundFontViewer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/BackupFileSaver.java
+++ b/blue-ui-core/src/blue/ui/core/BackupFileSaver.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/BluePluginManager.java
+++ b/blue-ui-core/src/blue/ui/core/BluePluginManager.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/CompileProcessor.java
+++ b/blue-ui-core/src/blue/ui/core/CompileProcessor.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/Installer.java
+++ b/blue-ui-core/src/blue/ui/core/Installer.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/MainToolbarAction.java
+++ b/blue-ui-core/src/blue/ui/core/MainToolbarAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/OSCActions.java
+++ b/blue-ui-core/src/blue/ui/core/OSCActions.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveToolBar.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveToolBar.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveToolbarAction.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveToolbarAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/BlueLiveTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/blueLive/KeyboardKeyRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/KeyboardKeyRenderer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/blueLive/LiveObjectRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/LiveObjectRenderer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/blueLive/LiveObjectsTableModel.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/LiveObjectsTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/blueLive/MidiKeyRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/MidiKeyRenderer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/blueLive/ScoPadReceiver.java
+++ b/blue-ui-core/src/blue/ui/core/blueLive/ScoPadReceiver.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/instrumentLibrary/InstrumentTreeDragSource.java
+++ b/blue-ui-core/src/blue/ui/core/instrumentLibrary/InstrumentTreeDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/instrumentLibrary/InstrumentTreeDropTarget.java
+++ b/blue-ui-core/src/blue/ui/core/instrumentLibrary/InstrumentTreeDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/midi/MidiInputEngine.java
+++ b/blue-ui-core/src/blue/ui/core/midi/MidiInputEngine.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2010
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/midi/MidiInputProcessorPanel.java
+++ b/blue-ui-core/src/blue/ui/core/midi/MidiInputProcessorPanel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/midi/VirtualKeyboardPanel.java
+++ b/blue-ui-core/src/blue/ui/core/midi/VirtualKeyboardPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/midi/VirtualKeyboardTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/midi/VirtualKeyboardTopComponent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/AddEffectEditorDialog.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/AddEffectEditorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/ChannelListPanel.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/ChannelListPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/ChannelOutComboBoxModel.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/ChannelOutComboBoxModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/ChannelPanel.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/ChannelPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectCategory.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectCategory.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectEditor.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectEditorDialog.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectEditorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectEditorManager.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectEditorManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectManager.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectTreeDragSource.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectTreeDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectTreeDropTarget.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectTreeDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectsLibrary.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectsLibrary.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectsLibraryAction.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectsLibraryAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectsObjectRegistry.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectsObjectRegistry.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectsPopup.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectsPopup.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/EffectsUtil.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/EffectsUtil.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/MixerTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/MixerTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/mixer/SendEditorManager.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/SendEditorManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/SubChannelListPanel.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/SubChannelListPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/SubChannelOutComboBoxModel.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/SubChannelOutComboBoxModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/mixer/TransferableEffect.java
+++ b/blue-ui-core/src/blue/ui/core/mixer/TransferableEffect.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/ArrangementEditPanel.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/ArrangementEditPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/InstrumentTreeDragSource.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/InstrumentTreeDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/InstrumentTreeDropTarget.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/InstrumentTreeDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/TransferableInstrument.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/TransferableInstrument.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/UserInstrumentLibrary.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/UserInstrumentLibrary.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/editor/BlueSynthBuilderEditor.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/editor/BlueSynthBuilderEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/orchestra/editor/blueX7/CsoundCodePanel.java
+++ b/blue-ui-core/src/blue/ui/core/orchestra/editor/blueX7/CsoundCodePanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/project/CurrentProjectsAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/CurrentProjectsAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/GenerateCsdAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/GenerateCsdAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/GenerateCsdToScreenAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/GenerateCsdToScreenAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/GenerateRealtimeCsdToScreenAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/GenerateRealtimeCsdToScreenAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/ProjectPropertiesTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/project/ProjectPropertiesTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/RenderStopProjectAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/RenderStopProjectAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/RenderToDiskAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/RenderToDiskAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/RenderToDiskAndPlayAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/RenderToDiskAndPlayAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/RenderToDiskUtility.java
+++ b/blue-ui-core/src/blue/ui/core/project/RenderToDiskUtility.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/project/ToggleLoopRenderingAction.java
+++ b/blue-ui-core/src/blue/ui/core/project/ToggleLoopRenderingAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/render/CommandProcessor.java
+++ b/blue-ui-core/src/blue/ui/core/render/CommandProcessor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/render/ParameterHelper.java
+++ b/blue-ui-core/src/blue/ui/core/render/ParameterHelper.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/render/RenderTimeManagerImpl.java
+++ b/blue-ui-core/src/blue/ui/core/render/RenderTimeManagerImpl.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/MarkersTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/score/MarkersTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/ModeListener.java
+++ b/blue-ui-core/src/blue/ui/core/score/ModeListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/ModeManager.java
+++ b/blue-ui-core/src/blue/ui/core/score/ModeManager.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/NoteProcessorChainEditor.java
+++ b/blue-ui-core/src/blue/ui/core/score/NoteProcessorChainEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/NoteProcessorDialog.java
+++ b/blue-ui-core/src/blue/ui/core/score/NoteProcessorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/ScoreNavigatorDialog.java
+++ b/blue-ui-core/src/blue/ui/core/score/ScoreNavigatorDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/ScoreTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/score/ScoreTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/TimelinePropertiesPanel.java
+++ b/blue-ui-core/src/blue/ui/core/score/TimelinePropertiesPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/AutomationLayerPanel.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/AutomationLayerPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/FreezeDialog.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/FreezeDialog.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/ScoreMouseWheelListener.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/ScoreMouseWheelListener.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/ScoreTimelineDropTargetListener.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/ScoreTimelineDropTargetListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundLayerPopup.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundLayerPopup.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectEditorTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectEditorTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectLibraryTableModel.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectLibraryTableModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectLibraryTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectLibraryTopComponent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectPopup.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectPopup.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectPropertiesTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectPropertiesTopComponent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectSelectionBus.java
+++ b/blue-ui-core/src/blue/ui/core/score/layers/soundObject/SoundObjectSelectionBus.java
@@ -1,6 +1,6 @@
 /*
   * blue - object composition environment for csound
-  *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+  *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
   * 
   *  This program is free software; you can redistribute it and/or modify
   *  it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/CodeEditor.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/CodeEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorChainTable.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorChainTable.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorChainTableModel.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorChainTableModel.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorEditProxy.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/NoteProcessorEditProxy.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/PropertyEditProxy.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/PropertyEditProxy.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/PropertyEditProxyEditor.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/PropertyEditProxyEditor.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/ScaleEditor.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/ScaleEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/ScaleSelector.java
+++ b/blue-ui-core/src/blue/ui/core/score/noteProcessorChain/ScaleSelector.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/soundLayer/LayersPanel.java
+++ b/blue-ui-core/src/blue/ui/core/score/soundLayer/LayersPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerLayout.java
+++ b/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerLayout.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerListPanel.java
+++ b/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerListPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerPanel.java
+++ b/blue-ui-core/src/blue/ui/core/score/soundLayer/SoundLayerPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/scratchPad/ScratchPadTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/scratchPad/ScratchPadTopComponent.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+ *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/script/ReinitializeJythonAction.java
+++ b/blue-ui-core/src/blue/ui/core/script/ReinitializeJythonAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundFile/AudioFilePlayer.java
+++ b/blue-ui-core/src/blue/ui/core/soundFile/AudioFilePlayer.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundFile/AudioFilePlayerTopComponent.java
+++ b/blue-ui-core/src/blue/ui/core/soundFile/AudioFilePlayerTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/AbstractLineObjectRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/AbstractLineObjectRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/BarRendererCache.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/BarRendererCache.java
@@ -1,6 +1,6 @@
 /*
   * blue - object composition environment for csound
-  *  Copyright (c) 2000-2009 Steven Yi (stevenyi@gmail.com)
+  *  Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
   * 
   *  This program is free software; you can redistribute it and/or modify
   *  it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/ExternalRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/ExternalRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/InstanceRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/InstanceRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/JMaskRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/JMaskRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/ObjectBuilderRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/ObjectBuilderRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/PythonObjectRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/PythonObjectRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/RhinoObjectRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/RhinoObjectRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/SoundRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/SoundRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/TrackerRenderer.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/TrackerRenderer.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
 
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/soundObject/renderer/audioFile/AudioWaveformCacheGenerator.java
+++ b/blue-ui-core/src/blue/ui/core/soundObject/renderer/audioFile/AudioWaveformCacheGenerator.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/toolbar/MainToolBar.java
+++ b/blue-ui-core/src/blue/ui/core/toolbar/MainToolBar.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/toolbar/TimePanel.java
+++ b/blue-ui-core/src/blue/ui/core/toolbar/TimePanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2011 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/tools/CodeRepositoryEditorAction.java
+++ b/blue-ui-core/src/blue/ui/core/tools/CodeRepositoryEditorAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/tools/OpenBlueShareAction.java
+++ b/blue-ui-core/src/blue/ui/core/tools/OpenBlueShareAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/tools/OpenFtableConverterAction.java
+++ b/blue-ui-core/src/blue/ui/core/tools/OpenFtableConverterAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/tools/OpenSoundFontViewerAction.java
+++ b/blue-ui-core/src/blue/ui/core/tools/OpenSoundFontViewerAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/tools/ScannedSynthesisMatrixEditorAction.java
+++ b/blue-ui-core/src/blue/ui/core/tools/ScannedSynthesisMatrixEditorAction.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2009
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/blue-ui-core/src/blue/ui/core/udo/EmbeddedOpcodeListPanel.java
+++ b/blue-ui-core/src/blue/ui/core/udo/EmbeddedOpcodeListPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/OpcodeListEditPanel.java
+++ b/blue-ui-core/src/blue/ui/core/udo/OpcodeListEditPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/TransferableUDO.java
+++ b/blue-ui-core/src/blue/ui/core/udo/TransferableUDO.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDOBuffer.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDOBuffer.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2007 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDOEditor.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDOEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2012 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDOLibraryPanel.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDOLibraryPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@csounds.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@csounds.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDORepositoryBrowser.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDORepositoryBrowser.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDOTreeDragSource.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDOTreeDragSource.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/src/blue/ui/core/udo/UDOTreeDropTarget.java
+++ b/blue-ui-core/src/blue/ui/core/udo/UDOTreeDropTarget.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-core/test/unit/src/blue/utility/MidiUtilitiesTest.java
+++ b/blue-ui-core/test/unit/src/blue/utility/MidiUtilitiesTest.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-utilities/src/blue/ui/utilities/SelectionModel.java
+++ b/blue-ui-utilities/src/blue/ui/utilities/SelectionModel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-ui-utilities/src/blue/ui/utilities/SimpleDocumentListener.java
+++ b/blue-ui-utilities/src/blue/ui/utilities/SimpleDocumentListener.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2005 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/blue-utilities/src/blue/utilities/MidiUtilities.java
+++ b/blue-utilities/src/blue/utilities/MidiUtilities.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2006 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/CeciliaModule.java
+++ b/cecilia/src/blue/soundObject/CeciliaModule.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CFileIn.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CFileIn.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CGraph.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CGraph.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CGraphPoint.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CGraphPoint.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CPopup.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CPopup.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CSeparator.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CSeparator.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CSlider.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CSlider.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CToggle.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CToggle.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/CeciliaModuleCompilationUnit.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/CeciliaModuleCompilationUnit.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/ceciliaModule/ModuleDefinition.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/ModuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/TCLScoreCompiler.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/TCLScoreCompiler.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilAlgorithm.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilAlgorithm.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilArg.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilArg.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilCompiler.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilCompiler.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilFunction.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilFunction.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilNode.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilNode.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilNoteList.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilNoteList.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilOperator.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/CybilOperator.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/co.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/co.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/gr.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/gr.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/li.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/li.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/lo.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/lo.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/ma.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/ma.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/pa.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/pa.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/pik.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/pik.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/ran.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/ran.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/ceciliaModule/cybil/sq.java
+++ b/cecilia/src/blue/soundObject/ceciliaModule/cybil/sq.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2004
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/editor/CeciliaModuleEditor.java
+++ b/cecilia/src/blue/soundObject/editor/CeciliaModuleEditor.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/CeciliaModuleImportDialog.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/CeciliaModuleImportDialog.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/DisplayLabel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/DisplayLabel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/EditorPanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/EditorPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/FileInputPanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/FileInputPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/FloatSlider.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/FloatSlider.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/Grapher.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/Grapher.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  * 
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherDisplayController.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherDisplayController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherEditPanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherEditPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherLineController.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherLineController.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherMenuBar.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherMenuBar.java
@@ -1,5 +1,5 @@
 /*
- * blue - object composition environment for csound Copyright (c) 2000-2003
+ * blue - object composition environment for csound Copyright (c) 2000-2014
  * Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherRowHeader.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherRowHeader.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherTimeBar.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/GrapherTimeBar.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2004 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/LineColors.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/LineColors.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/PropertiesPanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/PropertiesPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/SliderPanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/SliderPanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published

--- a/cecilia/src/blue/soundObject/editor/ceciliaModule/TogglePanel.java
+++ b/cecilia/src/blue/soundObject/editor/ceciliaModule/TogglePanel.java
@@ -1,6 +1,6 @@
 /*
  * blue - object composition environment for csound
- * Copyright (c) 2000-2003 Steven Yi (stevenyi@gmail.com)
+ * Copyright (c) 2000-2014 Steven Yi (stevenyi@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published


### PR DESCRIPTION
There are a lot of files changed here. You can verify that they are all legitimate changes with the following command:

~$ cat copyright.patch | grep "Steven Yi" | grep -v ^+ | grep -v ^+++ | wc -l

on the .patch file I've generated (seeing as github doesn't like too many files being changed).

|link removed|

There are 577 changes - to verify that all of them involve Steven Yi, the above will count how many removals contained the string "Steven Yi": 577 is the output

This patch was achieved by the following command:

~$ find . -name "*.xml" -o -name "*.java" -exec sed -i 's/2000-2003/2000-2014/g' '{}' \;

Where 2003 is replaced incrementally for 2004, 2005, etc.

fixes #294 